### PR TITLE
fix: Add missing imports in index.typ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Lineal is available through Typst Universe. Ensure you have installed Typst loca
 Get started by importing the package and populating your own `/content/<slug>.typ` files:
 
 ```typst
+#import "@preview/touying:0.5.3": lineal-theme
 #import "@preview/lineal:0.1.0": lineal-theme
 
 #show: lineal-theme.with(

--- a/main.typ
+++ b/main.typ
@@ -1,10 +1,7 @@
 #import "@preview/touying:0.5.3": *
 #import "@preview/numbly:0.1.0": *
 
-#import "src/theme.typ": lineal-theme
-#import "src/title.typ": title-slide
-#import "src/colour.typ": colour
-
+#import "lib.typ": lineal-theme, title-slide, colour
 
 #let brand = (
   wordmark: [$bb("L")"ineal"$],

--- a/src/index.typ
+++ b/src/index.typ
@@ -2,3 +2,4 @@
 #import "outline.typ": lineal-outline
 #import "progress.typ": lineal-progress-bar
 #import "title.typ": title-slide
+#import "theme.typ": lineal-theme

--- a/src/progress.typ
+++ b/src/progress.typ
@@ -40,10 +40,9 @@
     
     // Determine if this is the last section
     let heading-selector = selector(heading.where(level: 1)).before(here())
-    let level = counter(heading-selector)
+    let current-section-number = query(heading-selector).len()
     let headings = query(heading-selector)
     if headings.len() == 0 { return 0 }
-    let current-section-number = level.get().first()
 
     let is-last-section = total-sections == current-section-number
 
@@ -73,6 +72,7 @@
 
     let slides-covered-in-current-section = (
       query(selector(heading.where(level: 2)).after(current-section-start).before(here(), inclusive: false)).len()
+      + 1 // This makes the first slide of the section as "covered", otherwise there are gaps
     )
 
     let slides-remaining-in-current-section = (
@@ -85,7 +85,6 @@
       (
         query(selector(heading.where(level: 2)).after(here()).after(selector(heading.where(level: 1)).after(here()))).len()
         + query(selector(heading.where(level: 1)).after(here())).len()
-        + 1
       )
     }
 


### PR DESCRIPTION
Hi, this is a really beautiful theme!

I noticed that when importing the theme from another project, the `lineal-theme` function could not be resolved. There was a missing import line in `src/index.typ`. I also changed the import in `main.typ` to use the actual main file of the package so this kind of error is less likely in the future.